### PR TITLE
Fix TNT not damaging blocks

### DIFF
--- a/no-creeper-crators/src/main/java/io/github/stonley890/App.java
+++ b/no-creeper-crators/src/main/java/io/github/stonley890/App.java
@@ -4,19 +4,18 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.entity.Creeper;
 
 public class App extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
-
         getServer().getPluginManager().registerEvents(this, this);
-
     }
 
     @EventHandler
     public void onCreeperExplosion (EntityExplodeEvent event) {
-        event.blockList().clear();
+        if(event.getEntity() instanceof Creeper) event.blockList().clear();
     }
 
 }


### PR DESCRIPTION
Hi,
I noticed whilst using this plugin that TNT explosions also wouldn't break blocks, so I added a little check to see if the entity creating an explosion was a creeper and that seemed to fix it. Haven't done any extensive testing other than making sure creeper explosions still don't break blocks and that TNT explosions do.